### PR TITLE
Ubu 20: Ensure to apply the upstream patches

### DIFF
--- a/ubuntu20/Linux-PAM-1.3.1/debian/patches-applied/series
+++ b/ubuntu20/Linux-PAM-1.3.1/debian/patches-applied/series
@@ -33,3 +33,5 @@ fix-autoreconf.patch
 0003-Return-only-PAM_IGNORE-or-error-from-pam_motd.patch
 add_pam_faillock.patch
 pam_faillock_create_directory
+0001-pam_misc-make-length-of-misc_conv-configurable.patch
+0002-pam_misc-set-default-length-of-misc_conv-buffer-to-4.patch


### PR DESCRIPTION
Add the custom patches to the Ubu 20 debian/patches-applies/series
file so that they actually get applied when the .deb is built.
    
Signed-off-by: Jeff Squyres <jsquyres@cisco.com>